### PR TITLE
Made h5 backend for PyROA MCMC the default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ celerite >= 0.4.2
 colorama >= 0.4.6
 corner >= 2.2.1
 emcee >= 3.1.3
+h5py <= 3.12.1
 linmix @ git+https://github.com/jmeyers314/linmix.git
 matplotlib >= 3.6.2
 numba >= 0.56.4

--- a/src/pypetal/pyroa/utils.py
+++ b/src/pypetal/pyroa/utils.py
@@ -605,7 +605,8 @@ def run_pyroa(fnames, lc_dir, line_dir, line_names,
 
             args = (lc_dir, objname, filters, prior_arr[i,:,:],)
             kwargs = {'add_var':add_var[i], 'init_tau':[init_tau[i]], 'init_delta':init_delta, 'sig_level':sig_level,
-                      'delay_dist':delay_dist[i], 'psi_types':[psi_types[i]], 'Nsamples':nchain, 'Nburnin':nburn}
+                      'delay_dist':delay_dist[i], 'psi_types':[psi_types[i]], 'Nsamples':nchain, 'Nburnin':nburn,
+                      'use_backend':True}
 
             try:
                 signal.signal(signal.SIGALRM, handler)
@@ -655,7 +656,8 @@ def run_pyroa(fnames, lc_dir, line_dir, line_names,
 
         args = (lc_dir, objname, line_names, prior_arr,)
         kwargs = {'add_var':add_var, 'init_tau':init_tau, 'init_delta':init_delta, 'sig_level':sig_level,
-                  'delay_dist':delay_dist, 'psi_types':psi_types, 'Nsamples':nchain, 'Nburnin':nburn}
+                  'delay_dist':delay_dist, 'psi_types':psi_types, 'Nsamples':nchain, 'Nburnin':nburn,
+                  'use_backend':True}
 
         try:
             signal.signal(signal.SIGALRM, handler)

--- a/src/pypetal/pyroa/utils.py
+++ b/src/pypetal/pyroa/utils.py
@@ -602,6 +602,7 @@ def run_pyroa(fnames, lc_dir, line_dir, line_names,
         for i in range(len(fnames)-1):
 
             filters = [line_names[0], line_names[i+1]]
+            cwd = os.getcwd()
 
             args = (lc_dir, objname, filters, prior_arr[i,:,:],)
             kwargs = {'add_var':add_var[i], 'init_tau':[init_tau[i]], 'init_delta':init_delta, 'sig_level':sig_level,
@@ -637,6 +638,7 @@ def run_pyroa(fnames, lc_dir, line_dir, line_names,
 
 
                 signal.alarm(0)
+                shutil.move(cwd + '/Fit.h5', line_dir[i] + '/Fit.h5')
 
             except Exception as e:
                 proc.terminate()
@@ -645,6 +647,7 @@ def run_pyroa(fnames, lc_dir, line_dir, line_names,
                 print_error('Skipping and continuing to next line')
                 
                 fit_arr.append(None)
+                shutil.move(cwd + '/Fit.h5', line_dir[i] + '/Fit.h5')
                 continue
 
         return fit_arr
@@ -684,6 +687,7 @@ def run_pyroa(fnames, lc_dir, line_dir, line_names,
             fit = MyFit(line_dir)
             
             signal.alarm(0)
+            shutil.move(cwd + '/Fit.h5', line_dir + '/Fit.h5')
             
         except Exception as e:
             proc.terminate()
@@ -691,6 +695,7 @@ def run_pyroa(fnames, lc_dir, line_dir, line_names,
             print_error('PyROA timed out'.format(line_names[i+1]))
             
             fit = None
+            shutil.move(cwd + '/Fit.h5', line_dir + '/Fit.h5')
 
 
         return fit


### PR DESCRIPTION
Will now use the h5 backend for MCMC when running the PyROA module. This will produce a "Fit.h5" file in the current working directory (i.e., where pypetal is run from), and will move it to the proper "pyroa/" directory after the MCMC is finished. This allows for users to resume PyROA runs even if they timeout (this will be implemented in the future).